### PR TITLE
Unhandled promise rejections are deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,9 @@ const AutocompletePrompt = {
 			const l = Math.max(suggestions.length - 1, 0)
 			self.moveCursor(Math.min(l, self.cursor))
 			if (cb) cb()
-	  	})
+	  	}).catch((err) => {
+			self.emit('error', err)
+		})
 	}
 
 	, reset: function () {


### PR DESCRIPTION
Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

Added a .catch(...) block to be future ready.